### PR TITLE
Filter empty "where" 

### DIFF
--- a/lib/chroma/collection.ex
+++ b/lib/chroma/collection.ex
@@ -39,7 +39,7 @@ defmodule Chroma.Collection do
         where_document: Map.get(options, :where_document, %{}),
         include: Map.get(options, :include, ["metadatas", "documents", "distances"])
       }
-      |> Map.filter(fn {_, v} -> v != nil end)
+      |> Map.filter(fn {_, v} -> v != nil and v != %{} end)
 
     "#{Chroma.api_url()}/collections/#{id}/query"
     |> Req.post(json: json)


### PR DESCRIPTION
Empty "where" are unsupported since v0.5.17. Refer: https://docs.trychroma.com/updates/migration#v0.5.17